### PR TITLE
Optimize x86_64 logging offset calculation

### DIFF
--- a/basic_block.c
+++ b/basic_block.c
@@ -7,36 +7,24 @@
 
 #if GUM_NATIVE_CPU == GUM_CPU_AMD64
 
-static const guint8 afl_maybe_log_code[] = {
+static const guint8 afl_log_code[] = {
     0x9c,                                      /* pushfq */
     0x50,                                      /* push rax */
     0x51,                                      /* push rcx */
     0x52,                                      /* push rdx */
-    0x56,                                      /* push rsi */
 
-    0x89, 0xf8,                                /* mov eax, edi */
-    0xc1, 0xe0, 0x08,                          /* shl eax, 8 */
-    0xc1, 0xef, 0x04,                          /* shr edi, 4 */
-    0x31, 0xc7,                                /* xor edi, eax */
-    0x0f, 0xb7, 0xc7,                          /* movzx eax, di */
-    0x48, 0x8d, 0x0d, 0x46, 0x00, 0x00, 0x00,  /* lea rcx, sym._afl_instr_rms */
-    0x8b, 0x09,                                /* mov ecx, dword [rcx] */
-    0x48, 0x39, 0xc8,                          /* cmp rax, rcx */
-    0x73, 0x29,                                /* jae beach */
-    0x48, 0x8d, 0x0d, 0x30, 0x00, 0x00, 0x00,  /* lea rcx, sym._afl_area_ptr_ptr */
-    0x48, 0x8b, 0x09,                          /* mov rcx, qword [rcx] */
-    0x48, 0x8b, 0x09,                          /* mov rcx, qword [rcx] */
-    0x48, 0x8d, 0x15, 0x1b, 0x00, 0x00, 0x00,  /* lea rdx, sym._afl_prev_loc_ptr */
-    0x48, 0x8b, 0x32,                          /* mov rsi, qword [rdx] */
-    0x48, 0x8b, 0x36,                          /* mov rsi, qword [rsi] */
-    0x48, 0x31, 0xc6,                          /* xor rsi, rax */
-    0xfe, 0x04, 0x31,                          /* inc byte [rcx + rsi] */
-    0x48, 0xd1, 0xe8,                          /* shr rax, 1 */
-    0x48, 0x8b, 0x0a,                          /* mov rcx, qword [rdx] */
-    0x48, 0x89, 0x01,                          /* mov qword [rcx], rax */
+    0x48, 0x8d, 0x05, 0x27, 0x00, 0x00, 0x00,  /* lea rax, sym._afl_area_ptr_ptr */
+    0x48, 0x8b, 0x00,                          /* mov rax, qword [rax] */
+    0x48, 0x8b, 0x00,                          /* mov rax, qword [rax] */
+    0x48, 0x8d, 0x0d, 0x22, 0x00, 0x00, 0x00,  /* lea rcx, sym.___afl_prev_loc */
+    0x48, 0x8b, 0x11,                          /* mov rdx, qword [rcx] */
+    0x48, 0x8b, 0x12,                          /* mov rdx, qword [rdx] */
+    0x48, 0x31, 0xfa,                          /* xor rdx, rdi */
+    0xfe, 0x04, 0x10,                          /* inc byte [rax + rdx] */
+    0x48, 0xd1, 0xef,                          /* shr rdi, 1 */
+    0x48, 0x8b, 0x01,                          /* mov rax, qword [rcx] */
+    0x48, 0x89, 0x38,                          /* mov qword [rax], rdi */
 
-    /* beach: */
-    0x5e,                                      /* pop rsi */
     0x5a,                                      /* pop rdx */
     0x59,                                      /* pop rcx */
     0x58,                                      /* pop rax */
@@ -45,9 +33,8 @@ static const guint8 afl_maybe_log_code[] = {
     0xc3,                                      /* ret */
 
     /* Read-only data goes here: */
-        /* uint64_t* afl_prev_loc_ptr */
         /* uint8_t** afl_area_ptr_ptr */
-        /* unsigned int afl_instr_rms */
+        /* uint64_t* afl_prev_loc_ptr */
 };
 
 /*
@@ -56,23 +43,15 @@ static const guint8 afl_maybe_log_code[] = {
  *     #include <stdint.h>
  *     #include <stdlib.h>
  *
- *     #define MAP_SIZE_POW2 16
- *     #define MAP_SIZE (1 << MAP_SIZE_POW2)
- *
  *     uint8_t** afl_area_ptr_ptr;
- *     unsigned int afl_instr_rms;
  *     uint64_t* __afl_prev_loc;
  *
- *     void afl_maybe_log(size_t current_pc) {
- *         size_t offset = (current_pc >> 4) ^ (current_pc << 8);
- *         offset &= MAP_SIZE - 1;
- *         if (offset >= afl_instr_rms) return;
- *
+ *     void afl_log(size_t offset) {
  *         (*afl_area_ptr_ptr)[offset ^ *__afl_prev_loc]++;
  *         *__afl_prev_loc = offset >> 1;
  *     }
  *
- * With five push/pop pairs manually added to the prolog/epilog.
+ * With four push/pop pairs manually added to the prolog/epilog.
  */
 
 #else
@@ -100,33 +79,36 @@ void instr_basic_block(GumStalkerIterator* iterator, GumStalkerOutput* output, g
               printf("Transforming BB @ 0x%llx\n", current_pc);
 #endif
 #if GUM_NATIVE_CPU == GUM_CPU_AMD64
-              GumX86Writer* cw = output->writer.x86;
+              guint64 area_offset = (current_pc >> 4) ^ (current_pc << 8);
+              area_offset &= MAP_SIZE - 1;
+              if (area_offset < afl_instr_rms) {
+                  GumX86Writer* cw = output->writer.x86;
 
-              if (range->current_log_impl == 0 ||
-                      !gum_x86_writer_can_branch_directly_between(cw->pc, range->current_log_impl) ||
-                      !gum_x86_writer_can_branch_directly_between(cw->pc + 128, range->current_log_impl)) {
-                  gconstpointer after_log_impl = cw->code + 1;
+                  if (range->current_log_impl == 0 ||
+                          !gum_x86_writer_can_branch_directly_between(cw->pc, range->current_log_impl) ||
+                          !gum_x86_writer_can_branch_directly_between(cw->pc + 128, range->current_log_impl)) {
+                      gconstpointer after_log_impl = cw->code + 1;
 
-                  gum_x86_writer_put_jmp_near_label(cw, after_log_impl);
+                      gum_x86_writer_put_jmp_near_label(cw, after_log_impl);
 
-                  range->current_log_impl = cw->pc;
-                  gum_x86_writer_put_bytes(cw, afl_maybe_log_code, sizeof(afl_maybe_log_code));
+                      range->current_log_impl = cw->pc;
+                      gum_x86_writer_put_bytes(cw, afl_log_code, sizeof(afl_log_code));
 
-                  uint64_t* afl_prev_loc_ptr = &range->afl_prev_loc;
-                  uint8_t** afl_area_ptr_ptr = &afl_area_ptr;
-                  gum_x86_writer_put_bytes(cw, (const guint8 *) &afl_prev_loc_ptr, sizeof(afl_prev_loc_ptr));
-                  gum_x86_writer_put_bytes(cw, (const guint8 *) &afl_area_ptr_ptr, sizeof(afl_area_ptr_ptr));
-                  gum_x86_writer_put_bytes(cw, (const guint8 *) &afl_instr_rms, sizeof(afl_instr_rms));
+                      uint8_t** afl_area_ptr_ptr = &afl_area_ptr;
+                      uint64_t* afl_prev_loc_ptr = &range->afl_prev_loc;
+                      gum_x86_writer_put_bytes(cw, (const guint8 *) &afl_area_ptr_ptr, sizeof(afl_area_ptr_ptr));
+                      gum_x86_writer_put_bytes(cw, (const guint8 *) &afl_prev_loc_ptr, sizeof(afl_prev_loc_ptr));
 
-                  gum_x86_writer_put_label(cw, after_log_impl);
+                      gum_x86_writer_put_label(cw, after_log_impl);
+                  }
+
+                  gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP, -GUM_RED_ZONE_SIZE);
+                  gum_x86_writer_put_push_reg(cw, GUM_REG_RDI);
+                  gum_x86_writer_put_mov_reg_address(cw, GUM_REG_RDI, area_offset);
+                  gum_x86_writer_put_call_address(cw, range->current_log_impl);
+                  gum_x86_writer_put_pop_reg(cw, GUM_REG_RDI);
+                  gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP, GUM_RED_ZONE_SIZE);
               }
-
-              gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP, -GUM_RED_ZONE_SIZE);
-              gum_x86_writer_put_push_reg(cw, GUM_REG_RDI);
-              gum_x86_writer_put_mov_reg_address(cw, GUM_REG_RDI, GUM_ADDRESS(current_pc));
-              gum_x86_writer_put_call_address(cw, range->current_log_impl);
-              gum_x86_writer_put_pop_reg(cw, GUM_REG_RDI);
-              gum_x86_writer_put_lea_reg_reg_offset(cw, GUM_REG_RSP, GUM_REG_RSP, GUM_RED_ZONE_SIZE);
 #else
               gum_stalker_iterator_put_callout(iterator, on_basic_block, GSIZE_TO_POINTER (current_pc), NULL);
 #endif


### PR DESCRIPTION
By computing the area offset at each basic block's compile-time.

Kudos to @WorksButNotTested for spotting this!